### PR TITLE
Send image data as base64

### DIFF
--- a/app/functions/Communication.ts
+++ b/app/functions/Communication.ts
@@ -3,18 +3,19 @@ import type { GridCommunication } from '~/functions/types/GridCommunication';
 import { displayImageInElement, getImageData, startLoopingImages } from '~/functions/Cornerstone';
 import DicomAnonymizer from '~/functions/DicomAnonymizer';
 import { useGlobalStore } from '~/stores';
+import { Encode } from 'arraybuffer-encoding/base64/standard';
 
 class Communication {
   /**
    * Retrieve image data for given imageIndex
    */
-  getImageData(imageIndex: number): GridCommunication.Image {
+  async getImageData(imageIndex: number): Promise<GridCommunication.Image> {
     const imageData = getImageData(imageIndex);
     const store = useGlobalStore();
 
     return {
       imageId: store.imageIds[imageIndex],
-      imageData: DicomAnonymizer.anonymize(imageData),
+      imageData: Encode(DicomAnonymizer.anonymize(imageData)),
     };
   }
 
@@ -82,7 +83,7 @@ class Communication {
 
     for (let imageIdx = 0; imageIdx < store.imageIds.length; imageIdx++) {
       const serializedData: GridCommunication.Request.BodyData = {
-        image: this.getImageData(imageIdx),
+        image: await this.getImageData(imageIdx),
         grid: await this.getGridData(imageIdx),
       };
 

--- a/app/functions/types/GridCommunication.d.ts
+++ b/app/functions/types/GridCommunication.d.ts
@@ -4,7 +4,7 @@ import primaryLine = GridToolOptions.primaryLine;
 declare namespace GridCommunication {
   interface Image {
     imageId: string;
-    imageData: Uint8Array;
+    imageData: string;
   }
 
   declare namespace Request {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
         "@pinia/nuxt": "^0.4.8",
         "@tarotoma/cornerstone-tools": "^6.1.1",
         "@vuestic/nuxt": "^1.0.13",
+        "arraybuffer-encoding": "^1.1.0",
         "cornerstone-core": "^2.6.1",
         "cornerstone-math": "^0.1.10",
         "cornerstone-wado-image-loader": "^4.13.1",
@@ -2932,6 +2933,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/arraybuffer-encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arraybuffer-encoding/-/arraybuffer-encoding-1.1.0.tgz",
+      "integrity": "sha512-/zcDGcq/Vy9OQ2F7g5iRhWTW2AfrbB2ZeC3oOr9MJEfvF3cm1gn40wscjBp1vJmbu21tT7ktil/JTtYyfzjWog=="
     },
     "node_modules/async": {
       "version": "3.2.4",

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "@pinia/nuxt": "^0.4.8",
     "@tarotoma/cornerstone-tools": "^6.1.1",
     "@vuestic/nuxt": "^1.0.13",
+    "arraybuffer-encoding": "^1.1.0",
     "cornerstone-core": "^2.6.1",
     "cornerstone-math": "^0.1.10",
     "cornerstone-wado-image-loader": "^4.13.1",

--- a/app/server/api/grid.post.ts
+++ b/app/server/api/grid.post.ts
@@ -1,6 +1,10 @@
 import { defineEventHandler, readBody } from 'h3';
 import type { GridCommunication } from '~/functions/types/GridCommunication';
+// import { Decode } from 'arraybuffer-encoding/base64/standard';
 
+/**
+ * API endpoint - POST /api/grid
+ */
 export default defineEventHandler(async (event) => {
   const requestBody: GridCommunication.Request.Body = await readBody(event);
 
@@ -9,6 +13,8 @@ export default defineEventHandler(async (event) => {
   };
 
   for (const frameData of requestBody.data) {
+    // Image data has been anonymized and encoded to base64 because of minimizing payload to server
+    // const base64ToUint64Array = Decode(frameData.image.imageData);
     const grid: GridCommunication.Response.Grid = {
       imageId: frameData.image.imageId,
       primaryLines: frameData.grid.primaryLines,


### PR DESCRIPTION
In order to reduce the volume of data transferred, from now on image data will be encoded to base64 instead of sending it as JSON stringified Uint8array.